### PR TITLE
comentando data annotation de authorize do método DeleteCategory

### DIFF
--- a/API/Controllers/CategoryController.cs
+++ b/API/Controllers/CategoryController.cs
@@ -95,7 +95,6 @@ namespace API.Controllers
             }
         }
 
-        //[Authorize]
         [HttpDelete]
         [Route("DeleteCategory/{id}")]
         public ActionResult DeleteCategory(int id)

--- a/API/Controllers/CategoryController.cs
+++ b/API/Controllers/CategoryController.cs
@@ -95,7 +95,7 @@ namespace API.Controllers
             }
         }
 
-        [Authorize]
+        //[Authorize]
         [HttpDelete]
         [Route("DeleteCategory/{id}")]
         public ActionResult DeleteCategory(int id)


### PR DESCRIPTION
### Description
Foi realizada a melhoria de não precisar mais de authorization para executar o método da api de DeleteCategory. O mesmo foi só comentado para caso seja necessário ser ativo novamente.

### Screenshot
- Screenshots do que foi feito
![image](https://user-images.githubusercontent.com/86421180/231011162-146e93d5-08de-4f08-80a2-5ed5f8120ce1.png)
